### PR TITLE
two new params added, '-original' and '-final'

### DIFF
--- a/ensepro/__init__.py
+++ b/ensepro/__init__.py
@@ -52,6 +52,21 @@ def analisar_frase(frase: str):
         raise ex
 
 
+def comparar_frase(frase1: Frase, frase2: Frase,
+                   file=None,
+                   termos_relevantes=False,
+                   sinonimos=False,
+                   complementos_nominais=False,
+                   locucoes_verbais=False,
+                   tags=False,
+                   arvore=False,
+                   resposta=False):
+    # TODO implementar
+    print("Método ainda não implementado")
+
+    pass
+
+
 def frase_pretty_print(frase: Frase,
                        file=None,
                        termos_relevantes=False,
@@ -59,9 +74,7 @@ def frase_pretty_print(frase: Frase,
                        complementos_nominais=False,
                        locucoes_verbais=False,
                        tags=False,
-                       arvore=False,
-                       resposta=False,
-                       verbose=False):
+                       arvore=False):
     if not isinstance(frase, Frase):
         raise Exception("Não é um objeto Frase.")
 
@@ -69,17 +82,17 @@ def frase_pretty_print(frase: Frase,
     print("--> Tipo:", frase.tipo, file=file)
     print("--> Voz:", frase.voz, file=file)
 
-    if termos_relevantes or verbose:
+    if termos_relevantes:
         print("--> Termos Relevantes:", file=file)
         if frase.termos_relevantes:
             for index, palavra in enumerate(frase.termos_relevantes):
                 print("----> TR {0}:".format(index), palavra, file=file)
-                if sinonimos or verbose:
+                if sinonimos:
                     print("--------> Sinonimos: " + str(palavra.sinonimos), file=file)
         else:
             print("----> Nenhuma.", file=file)
 
-    if complementos_nominais or verbose:
+    if complementos_nominais:
         print("--> Complementos Nominais:", file=file)
         if frase.complementos_nominais:
             for index, cn in enumerate(frase.complementos_nominais):
@@ -87,7 +100,7 @@ def frase_pretty_print(frase: Frase,
         else:
             print("----> Nenhum.", file=file)
 
-    if locucoes_verbais or verbose:
+    if locucoes_verbais:
         print("--> Locuções Verbais:", file=file)
         if frase.locucao_verbal:
             for index, lv in enumerate(frase.locucao_verbal):
@@ -95,7 +108,7 @@ def frase_pretty_print(frase: Frase,
         else:
             print("----> Nenhum.", file=file)
 
-    if tags or verbose:
+    if tags:
         print("--> Tags das palavras", file=file)
         for palavra in frase.palavras:
             print("----> Palavra[{:>3}] {:>20} - {:<20}==> {}".format(palavra.id, palavra.palavra_original,
@@ -103,42 +116,41 @@ def frase_pretty_print(frase: Frase,
                                                                       str(palavra.tags)),
                   file=file)
 
-    if arvore or verbose:
+    if arvore:
         frase.arvore.to_nltk_tree().pretty_print(stream=file)
 
-    if resposta or verbose:
-        if frase.resposta:
-            print("\nMelhores respostas:", file=file)
-            import ensepro.configuracoes as configuracoes
-            from ensepro import ConsultaConstantes
-            resultado_resumido = configuracoes.get_config(ConsultaConstantes.RESULTADO_RESUMIDO)
 
-            for index, tripla in enumerate(frase.resposta):
-                to_print = []
-                to_print.append("score:" + "{0:.3f}".format(tripla["score"]))
-                temp = []
-                for value in tripla["triples"]:
-                    for key in value:
-                        temp.append(value[key])
+def resposta_pretty_print(resposta, file=None):
+    if not resposta:
+        print("Nenhuma resposta encontrada.\n", file=file)
 
-                to_print.append("[" + ' | '.join(temp) + "]")
-                to_print.append(" ")
-                if not resultado_resumido:
-                    temp = []
-                    for value in tripla["details"]["metrics"]["scoreMetrics"]:
-                        temp.append("{0:.3f}".format(value))
-                    to_print.append("metrics: [" + ' '.join(temp) + "]")
+    print("\nMelhores respostas:", file=file)
+    import ensepro.configuracoes as configuracoes
+    from ensepro import ConsultaConstantes
+    resultado_resumido = configuracoes.get_config(ConsultaConstantes.RESULTADO_RESUMIDO)
 
-                    temp = []
-                    for value in tripla["details"]["metrics"]["metrics"]:
-                        temp.append("{0:.2f}".format(value["weight"]) + "(" + value["policy"] + ")")
-                    to_print.append("metricsClass: [" + ','.join(temp) + "]")
+    for index, tripla in enumerate(resposta):
+        to_print = []
+        to_print.append("score:" + "{0:.3f}".format(tripla["score"]))
+        temp = []
+        for value in tripla["triples"]:
+            for key in value:
+                temp.append(value[key])
 
-                print(str(index), "-", ' '.join(to_print), file=file)
+        to_print.append("[" + ' | '.join(temp) + "]")
+        to_print.append(" ")
+        if not resultado_resumido:
+            temp = []
+            for value in tripla["details"]["metrics"]["scoreMetrics"]:
+                temp.append("{0:.3f}".format(value))
+            to_print.append("metrics: [" + ' '.join(temp) + "]")
 
+            temp = []
+            for value in tripla["details"]["metrics"]["metrics"]:
+                temp.append("{0:.2f}".format(value["weight"]) + "(" + value["policy"] + ")")
+            to_print.append("metricsClass: [" + ','.join(temp) + "]")
 
-        else:
-            print("Nenhuma resposta encontrada.", file=file)
+        print(str(index), "-", ' '.join(to_print), file=file)
 
 
 def save_as_json(value, filename, indent=4, sort_keys=False):

--- a/ensepro/cbc/__init__.py
+++ b/ensepro/cbc/__init__.py
@@ -99,20 +99,19 @@ def __verbos_from_frase(frase: Frase):
 
 def consultar(frase: Frase):
     logger.info("Executando consulta e montagem das queries da frase")
-    frase_atualizada = atualizar_frase(frase)
-    if not frase_atualizada:
+    if not frase:
         return None
 
-    substantivos_proprios = __sub_proprio_from_frase(frase_atualizada)
-    substantivos_comuns = __sub_comum_from_frase(frase_atualizada)
-    verbos = __verbos_from_frase(frase_atualizada)
+    substantivos_proprios = __sub_proprio_from_frase(frase)
+    substantivos_comuns = __sub_comum_from_frase(frase)
+    verbos = __verbos_from_frase(frase)
 
     params = {}
     params["termos"] = {}
     params["termos"]["PROP"] = substantivos_proprios
     params["termos"]["SUB"] = substantivos_comuns
     params["termos"]["VERB"] = verbos
-    params["frase"] = frase_atualizada
+    params["frase"] = frase
 
     resultado_final = answer_generator.execute_integration(params)
 

--- a/ensepro/cbc/answer_generator/steps/elastic_search_step.py
+++ b/ensepro/cbc/answer_generator/steps/elastic_search_step.py
@@ -6,10 +6,10 @@
 
 """
 
+from ensepro import save_as_json, LoggerConstantes
 from ensepro.cbc.fields import Field
 from ensepro.elasticsearch.searches import list_parcial_match_search
 from ensepro.utils.string_utils import remover_acentos
-from ensepro import save_as_json, LoggerConstantes
 from ensepro.cbc.answer_generator import helper
 
 fields_partial_match = [

--- a/ensepro/classes/frase.py
+++ b/ensepro/classes/frase.py
@@ -75,13 +75,11 @@ class Frase:
         self.__complementos_nominais = complementos_nominais.get(self)
         return self.__complementos_nominais
 
+    def set_resposta(self, resposta):
+        self.__resposta = resposta
+
     @property
     def resposta(self):
-        if self.__resposta:
-            return self.__resposta
-
-        from ensepro.cbc import consultar
-        self.__resposta = consultar(self)
         return self.__resposta
 
     def get_palavras(self, condicao, **args):
@@ -104,7 +102,8 @@ class Frase:
             "arvore": str(self.__arvore),
             "tipo": self.__tipo,
             "locucao_verbal": self.__locucao_verbal,
-            "termos_relevantes": [palavra.__to_json__() for palavra in self.__termos_relevantes] if self.__termos_relevantes else None,
+            "termos_relevantes": [palavra.__to_json__() for palavra in
+                                  self.__termos_relevantes] if self.__termos_relevantes else None,
             "voz": str(self.__voz),
             "complementos_nominais": self.__complementos_nominais,
             "resposta": self.__resposta
@@ -120,11 +119,11 @@ class Frase:
         return \
             "Frase={{id={0}, palavras={1}, tipo={2}, locucao_verbal={3}, voz={4}}}" \
             "".format(
-                    str(self.id),
-                    str(self.palavras),
-                    str(self.__tipo),
-                    str(self.__locucao_verbal),
-                    str(self.__voz)
+                str(self.id),
+                str(self.palavras),
+                str(self.__tipo),
+                str(self.__locucao_verbal),
+                str(self.__voz)
             )
 
     def __repr__(self):

--- a/main/main_params.py
+++ b/main/main_params.py
@@ -16,22 +16,6 @@ def arquivo_existente(parser, arg):
 
 
 def get_args():
-    """
-    -frase FRASE
-    -arquivo-frases FILE
-    -save-json
-    -save-txt
-    -tr
-    -sin
-    -cn
-    -lv
-    -arvore
-    -tags
-    -resposta
-    -verbose
-    -quiet
-    """
-
     from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
     parser = ArgumentParser(description=__doc__, formatter_class=ArgumentDefaultsHelpFormatter)
 
@@ -39,77 +23,89 @@ def get_args():
                         default=None,
                         type=str,
                         dest="frase",
-                        help="Frase a ser analisada")
+                        help="Frase a ser analisada.")
 
     parser.add_argument("-arquivo-frases",
                         default=None,
                         type=lambda x: arquivo_existente(parser, x),
                         dest="arquivo_frases",
-                        help="Arquivo contento frases a serem analisadas")
+                        help="Arquivo contento frases a serem analisadas.")
 
     parser.add_argument("-save-json",
                         dest="save_json",
-                        help="Salvará os resultdos em um arquivo json",
+                        help="Salvará os resultdos em um arquivo json.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-save-txt",
                         dest="save_txt",
-                        help="Salvará os resultdos em um arquivo txt",
+                        help="Salvará os resultdos em um arquivo txt.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-tr",
                         dest="termos_relevantes",
-                        help="Indica para printar/salvar os termos relevantes",
+                        help="Indica para printar/salvar os termos relevantes.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-sin",
                         dest="sinonimos",
-                        help="Indica para printar/salvar os sinonimos dos termos relevantes",
+                        help="Indica para printar/salvar os sinonimos dos termos relevantes.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-cn",
                         dest="complementos_nominais",
-                        help="Indica para printar/salvar os complementos nominais",
+                        help="Indica para printar/salvar os complementos nominais.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-lv",
                         dest="locucoes_verbais",
-                        help="Indica para printar/salvar os locucoes verbais",
+                        help="Indica para printar/salvar os locucoes verbais.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-arvore",
                         dest="arvore",
-                        help="Indica para printar/salvar a arvore gráfica da frase",
+                        help="Indica para printar/salvar a arvore gráfica da frase.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-tags",
                         dest="tags",
-                        help="Indica para printar/salvar os as tags das frases no arquivo txt",
+                        help="Indica para printar/salvar os as tags das frases no arquivo txt.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-resposta",
                         dest="resposta",
-                        help="Indica se deve buscar uma resposta",
+                        help="Indica se deve buscar uma resposta.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-verbose",
                         dest="verbose",
-                        help="Indica para printar/salvar todos os valores existentes",
+                        help="Indica para printar/salvar todos os valores existentes.",
                         action="store_true",
                         default=False)
 
     parser.add_argument("-quiet",
                         dest="quiet",
-                        help="Indica para não printar nada enquanto faz a execução",
+                        help="Indica para não printar nada enquanto faz a execução.",
+                        action="store_true",
+                        default=False)
+
+    parser.add_argument("-original",
+                        dest="original",
+                        help="Define que os resultados são referentes a frase passada por parâmetro.",
+                        action="store_true",
+                        default=False)
+
+    parser.add_argument("-final",
+                        dest="final",
+                        help="Define que os resultados são referentes a frase final, depois de passar pelo modulo CBC e ser atualizada.",
                         action="store_true",
                         default=False)
 

--- a/main/main_utils.py
+++ b/main/main_utils.py
@@ -21,17 +21,37 @@ def carregar_frases(arquivo):
     return frases
 
 
+def print_frase(ensepro, frase, args, file=None):
+    ensepro.frase_pretty_print(
+        frase,
+        file=file,
+        termos_relevantes=args.verbose or args.termos_relevantes,
+        sinonimos=args.verbose or args.sinonimos,
+        complementos_nominais=args.verbose or args.complementos_nominais,
+        locucoes_verbais=args.verbose or args.locucoes_verbais,
+        tags=args.verbose or args.tags,
+        arvore=args.verbose or args.arvore
+    )
+
+
+def comparar_frases(ensepro, frase1, frase2, args, file=None):
+    ensepro.comparar_frases(
+        frase1,
+        frase2,
+        file=file,
+        termos_relevantes=args.verbose or args.termos_relevantes,
+        sinonimos=args.verbose or args.sinonimos,
+        complementos_nominais=args.verbose or args.complementos_nominais,
+        locucoes_verbais=args.verbose or args.locucoes_verbais,
+        tags=args.verbose or args.tags,
+        arvore=args.verbose or args.arvore
+    )
+
+
 def print_frases(ensepro, frases, args, file=None):
     for frase in frases:
-        ensepro.frase_pretty_print(
-                frase,
-                file=file,
-                termos_relevantes=args.termos_relevantes,
-                sinonimos=args.sinonimos,
-                complementos_nominais=args.complementos_nominais,
-                locucoes_verbais=args.locucoes_verbais,
-                tags=args.tags,
-                arvore=args.arvore,
-                resposta=args.resposta,
-                verbose=args.verbose
-        )
+        print_frase(ensepro, frase, args, file=file)
+
+
+def print_resposta(ensepro, resposta, file=None):
+    ensepro.resposta_pretty_print(resposta, file=file)


### PR DESCRIPTION
This merge request resolves #30.

The param `-original` indicates that all information printed is from the analyses of the original phrase (the phrase passed by param).
The param `-final` indicates that all information printed is from the final analyses/state of the original phrase. This is the phrase that is considered in the CBC module and its use to find the answer.

The order and current struct of ensepro was changed to support this implementation. Before this implementation, to only show the keywords from the final phrase it was necessary find the answer (call Elasticsearch, java, etc). 
With this implementation, we can obtain all info about the final phrase without finding the answer.

Also was created one method to compare phrase, but without any implementation, so in the future will
be easier to implement.